### PR TITLE
RFC: Use HeatCool instead of Auto

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ function ecobeeToThermostatMode(mode: string): ThermostatMode {
     case "heat":
       return ThermostatMode.Heat;
     case "auto":
-      return ThermostatMode.Auto;
+      return ThermostatMode.HeatCool;
   }
 
   return ThermostatMode.Off;
@@ -41,7 +41,7 @@ function thermostatModeToEcobee(mode: ThermostatMode): string {
       return "cool";
     case ThermostatMode.Heat:
       return "heat";
-    case ThermostatMode.Auto:
+    case ThermostatMode.HeatCool:
       return "auto";
   }
 
@@ -69,7 +69,7 @@ class EcobeeThermostat extends ScryptedDeviceBase implements HumiditySensor, The
     this.provider = provider;
 
     this.temperatureUnit = TemperatureUnit.F
-    const modes: ThermostatMode[] = [ThermostatMode.Cool, ThermostatMode.Heat, ThermostatMode.Auto, ThermostatMode.Off];
+    const modes: ThermostatMode[] = [ThermostatMode.Cool, ThermostatMode.Heat, ThermostatMode.HeatCool, ThermostatMode.Off];
     this.thermostatAvailableModes = modes;
 
     let humModes: HumidityMode[] = [HumidityMode.Auto, HumidityMode.Humidify, HumidityMode.Off];
@@ -252,8 +252,8 @@ class EcobeeThermostat extends ScryptedDeviceBase implements HumiditySensor, The
   async setThermostatSetpoint(degrees: number): Promise<void> {
     this.console.log(`[${this.name}] (${new Date().toLocaleString()}) setThermostatSetpoint ${degrees}C`)
 
-    if (this.thermostatMode === ThermostatMode.Auto) {
-      this.console.log(`[${this.name}] (${new Date().toLocaleString()}) setThermostatSetpoint not running in auto mode`)
+    if (this.thermostatMode === ThermostatMode.HeatCool) {
+      this.console.log(`[${this.name}] (${new Date().toLocaleString()}) setThermostatSetpoint not running in heatcool mode`)
       return;
     }
 


### PR DESCRIPTION
I'm submitting a PR for comment per the discussion on the Scrypted Discord.

Presently, the Scrypted HomeKit plugin sets the thermostat mode to 'ThermostatMode.Auto' mode when the 'Auto' mode is selected in the Home app, despite exposing separate Heating/Cooling thresholds. I have published a PR on the Scrypted repository (koush/scrypted#470) which would change the plugin to expose a single threshold if only 'ThermostatMode.Auto' is available and separate thresholds if 'ThermostatMode.HeatCool' is available; this would require the ecobee plugin to be changed to expose the 'ThermostatMode.HeatCool' mode in place of 'ThermostatMode.Auto'. This change should bring the HomeKit plugin into line with the Google Home plugin, which (I believe, though I may be wrong) should behave similarly.